### PR TITLE
Add linux/arm64 platform to docker builds

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -26,3 +26,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Publishes linux/arm64 docker images.

Relevant documentation: https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md
