### PR TITLE
Add support for using predefined access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ docker run --rm -it nim65s/matrix-webhook -h
 ```
 
 ```
-usage: python -m matrix_webhook [-h] [-H HOST] [-P PORT] [-u MATRIX_URL] -i MATRIX_ID -p MATRIX_PW -k API_KEY [-v]
+usage: python -m matrix_webhook [-h] [-H HOST] [-P PORT] [-u MATRIX_URL] -i MATRIX_ID [-p MATRIX_PW] [-t MATRIX_TOKEN] -k API_KEY [-v]
 
 Configuration for Matrix Webhook.
 
-
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -H HOST, --host HOST  host to listen to. Default: `''`. Environment variable: `HOST`
   -P PORT, --port PORT  port to listed to. Default: 4785. Environment variable: `PORT`
@@ -49,7 +48,9 @@ optional arguments:
   -i MATRIX_ID, --matrix-id MATRIX_ID
                         matrix user-id. Required. Environment variable: `MATRIX_ID`
   -p MATRIX_PW, --matrix-pw MATRIX_PW
-                        matrix password. Required. Environment variable: `MATRIX_PW`
+                        matrix password. Either this or token required. Environment variable: `MATRIX_PW`
+  -t MATRIX_TOKEN, --matrix-token MATRIX_TOKEN
+                        matrix access token. Either this or password required. Environment variable: `MATRIX_TOKEN`
   -k API_KEY, --api-key API_KEY
                         shared secret to use this service. Required. Environment variable: `API_KEY`
   -v, --verbose         increment verbosity level

--- a/matrix_webhook/app.py
+++ b/matrix_webhook/app.py
@@ -17,8 +17,12 @@ async def main(event):
 
     matrix client login & start web server
     """
-    LOGGER.info(f"Log in {conf.MATRIX_ID=} on {conf.MATRIX_URL=}")
-    await utils.CLIENT.login(conf.MATRIX_PW)
+    if conf.MATRIX_PW:
+        LOGGER.info(f"Log in {conf.MATRIX_ID=} on {conf.MATRIX_URL=}")
+        await utils.CLIENT.login(conf.MATRIX_PW)
+    else:
+        LOGGER.info(f"Restoring log in {conf.MATRIX_ID=} on {conf.MATRIX_URL=}")
+        utils.CLIENT.access_token = conf.MATRIX_TOKEN
 
     server = web.Server(handler.matrix_webhook)
     runner = web.ServerRunner(server)

--- a/matrix_webhook/conf.py
+++ b/matrix_webhook/conf.py
@@ -36,11 +36,21 @@ parser.add_argument(
 parser.add_argument(
     "-p",
     "--matrix-pw",
-    help="matrix password. Required. Environment variable: `MATRIX_PW`",
+    help="matrix password. Either this or token required. Environment variable: `MATRIX_PW`",
     **(
         {"default": os.environ["MATRIX_PW"]}
         if "MATRIX_PW" in os.environ
-        else {"required": True}
+        else {}
+    ),
+)
+parser.add_argument(
+    "-t",
+    "--matrix-token",
+    help="matrix access token. Either this or password required. Environment variable: `MATRIX_TOKEN`",
+    **(
+        {"default": os.environ["MATRIX_TOKEN"]}
+        if "MATRIX_TOKEN" in os.environ
+        else {}
     ),
 )
 parser.add_argument(
@@ -59,9 +69,14 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+if not (args.matrix_pw or args.matrix_token):
+    print("Error: Either MATRIX_PW or MATRIX_TOKEN needs to be provided")
+    exit(1)
+
 SERVER_ADDRESS = (args.host, args.port)
 MATRIX_URL = args.matrix_url
 MATRIX_ID = args.matrix_id
 MATRIX_PW = args.matrix_pw
+MATRIX_TOKEN = args.matrix_token
 API_KEY = args.api_key
 VERBOSE = args.verbose

--- a/matrix_webhook/utils.py
+++ b/matrix_webhook/utils.py
@@ -44,7 +44,8 @@ async def join_room(room_id):
             if isinstance(resp, JoinError):
                 if resp.status_code == "M_UNKNOWN_TOKEN":
                     LOGGER.warning("Reconnecting")
-                    await CLIENT.login(conf.MATRIX_PW)
+                    if conf.MATRIX_PW:
+                        await CLIENT.login(conf.MATRIX_PW)
                 else:
                     return create_json_response(error_map(resp), resp.message)
             else:
@@ -67,7 +68,8 @@ async def send_room_message(room_id, content):
             if isinstance(resp, RoomSendError):
                 if resp.status_code == "M_UNKNOWN_TOKEN":
                     LOGGER.warning("Reconnecting")
-                    await CLIENT.login(conf.MATRIX_PW)
+                    if conf.MATRIX_PW:
+                        await CLIENT.login(conf.MATRIX_PW)
                 else:
                     return create_json_response(error_map(resp), resp.message)
             else:


### PR DESCRIPTION
This is mainly to allow using the webhook receiver on Matrix servers where username/password login isn't supported, so that the bot can instead be provided an access token for an existing sign-in.

For encryption to work - if that's planned at some point, it'll also need support for specifying the device ID, and then use the `AsyncClient.restore_login()` function instead of just setting the access token directly.