### PR TITLE
add a healthcheck for load balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ options:
   -v, --verbose         increment verbosity level
 ```
 
+### Healthcheck
+
+For load balancers which require a healthcheck endpoint to validate the availability of the service, the `/health` path can be used. The endpoint will return a **HTTP 200** status and a json document.
+
+Using the Healthcheck endpoint with Traefik and docker-compose:
+
+```yaml
+version: '3'
+
+...
+
+services:
+  bot:
+    ...
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.matrix-webhook.rule: "Host(`${CHATONS_SERVICE:-matrixwebhook}.${CHATONS_DOMAIN:-localhost}`)"
+      traefik.http.services.matrix-webhook.loadbalancer.healthcheck.path: /health
+```
 
 ## Dev
 
@@ -84,6 +103,7 @@ docker-compose up -d
 curl -d '{"body":"new contrib from toto: [44](http://radio.localhost/map/#44)", "key": "secret"}' \
   'http://matrixwebhook.localhost/!DPrUlnwOhBEfYwsDLh:matrix.org'
 ```
+
 (or localhost:4785 without docker)
 
 ### For Github

--- a/matrix_webhook/handler.py
+++ b/matrix_webhook/handler.py
@@ -18,6 +18,11 @@ async def matrix_webhook(request):
     This one handles a POST, checks its content, and forwards it to the matrix room.
     """
     LOGGER.debug(f"Handling {request=}")
+
+    # healthcheck
+    if request.rel_url.path == "/health":
+        return utils.create_json_response(HTTPStatus.OK, "OK")
+
     data_b = await request.read()
 
     try:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -171,3 +171,7 @@ class BotTest(unittest.IsolatedAsyncioTestCase):
             bot_req({"body": "Re"}, KEY, room.room_id),
             {"status": 200, "ret": "OK"},
         )
+
+    async def test_healthcheck(self):
+        """Check the healthcheck endpoint returns 200."""
+        self.assertEqual(bot_req(room_id="health"), {"status": 200, "ret": "OK"})


### PR DESCRIPTION
Hi,

I am using traefik as load balancer for my docker setup. Traefik usually needs a path which returns a 200 status as healthcheck endpoint. I've added a simple healthcheck path.

Probably something that also other users can use.