### PR TITLE
Add integration with Github Release Notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Add a Google Chat integration with an URL ending with `?formatter=gitlab_gchat&k
 
 Add a Microsoft Teams integration with an URL ending with `?formatter=gitlab_teams&key=API_KEY`
 
+#### Github Release Notifier
+
+To receiver notifications about new releases of projects hosted at github.com you can add a matrix webhook ending with `?formatter=grn&key=API_KEY` to [Github Release Notifier (grn)](https://github.com/femtopixel/github-release-notifier).  
+
 ## Test room
 
 [#matrix-webhook:tetaneutral.net](https://matrix.to/#/!DPrUlnwOhBEfYwsDLh:matrix.org)

--- a/matrix_webhook/formatters.py
+++ b/matrix_webhook/formatters.py
@@ -71,3 +71,12 @@ def gitlab_teams(data, headers):
 
     data["body"] = "  \n".join(body)
     return data
+
+
+def grn(data, headers):
+    """Pretty-print a github release notifier (grn) notification."""
+    version, title, author, package  = (
+         data[k] for k in ["version", "title", "author", "package_name"]
+    )
+    data["body"] = f"### {package} - {version}\n\n{title}\n\n[{author} released new version **{version}** for **{package}**](https://github.com/{package}/releases/tag/{version}).\n\n"
+    return data


### PR DESCRIPTION
[Github Release Notifier](https://github.com/femtopixel/github-release-notifier) can watch projects at github.com for new releases and send out notifications via webhook each time a new release is detected. 

Out of the box the GRN webhook payload is not compatible with matrix-webhook and therefore a new formatter is necessary. 

This PR adds a formatter for github release notifier notifications and updates the README. 

I tested the code with may private "Release Infos" matrix room.

<img width="628" alt="image" src="https://github.com/nim65s/matrix-webhook/assets/2663487/2fc0ff0d-2aa0-4025-8afa-6aff1180ac82">
